### PR TITLE
Implement CDK support for new agent features

### DIFF
--- a/lambda/fijian/src/handler.ts
+++ b/lambda/fijian/src/handler.ts
@@ -1,19 +1,32 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import { BedrockRuntimeClient, InvokeModelCommand } from '@aws-sdk/client-bedrock-runtime';
 
 export const handler = async (
   event: APIGatewayProxyEvent
 ): Promise<APIGatewayProxyResult> => {
-  if (event.httpMethod !== 'GET' || event.path !== '/learn') {
-    return { statusCode: 405, body: 'Method Not Allowed' };
+  if (event.httpMethod === 'GET' && event.path === '/learn') {
+    const modules = [
+      { title: 'Basic Greetings', pages: 2, summary: 'This is a summary of the module content.' },
+      { title: 'Numbers', pages: 1, summary: 'This is a summary of the module content.' }
+    ];
+    return {
+      statusCode: 200,
+      body: JSON.stringify({ modules })
+    };
   }
 
-  const modules = [
-    { title: 'Basic Greetings', pages: 2, summary: 'This is a summary of the module content.' },
-    { title: 'Numbers', pages: 1, summary: 'This is a summary of the module content.' }
-  ];
+  if (event.httpMethod === 'POST' && event.path === '/chat') {
+    const body = JSON.parse(event.body || '{}');
+    const br = new BedrockRuntimeClient({});
+    const res = await br.send(new InvokeModelCommand({
+      modelId: 'anthropic.claude-3-haiku-20240307',
+      contentType: 'application/json',
+      accept: 'application/json',
+      body: JSON.stringify({ messages: [{ role: 'user', content: body.input || '' }], max_tokens: 100 })
+    }));
+    const text = Buffer.from(res.body).toString();
+    return { statusCode: 200, body: text };
+  }
 
-  return {
-    statusCode: 200,
-    body: JSON.stringify({ modules })
-  };
+  return { statusCode: 405, body: 'Method Not Allowed' };
 };

--- a/lambda/ingestion-agent/index.ts
+++ b/lambda/ingestion-agent/index.ts
@@ -1,0 +1,36 @@
+import { DynamoDBClient, ScanCommand, UpdateItemCommand } from '@aws-sdk/client-dynamodb';
+import { LambdaClient, InvokeCommand } from '@aws-sdk/client-lambda';
+
+const ddb = new DynamoDBClient({});
+const lambda = new LambdaClient({});
+
+const QUEUE_TABLE = process.env.ARTICLE_QUEUE_TABLE!;
+const INGESTION_FUNCTION_NAME = process.env.INGESTION_FUNCTION_NAME!;
+
+export const handler = async () => {
+  const scan = await ddb.send(new ScanCommand({
+    TableName: QUEUE_TABLE,
+    FilterExpression: 'attribute_not_exists(processedAt)',
+    Limit: 5
+  }));
+
+  const tasks = scan.Items || [];
+  for (const item of tasks) {
+    const url = item.url?.S;
+    if (!url) continue;
+    await lambda.send(new InvokeCommand({
+      FunctionName: INGESTION_FUNCTION_NAME,
+      InvocationType: 'Event',
+      Payload: Buffer.from(JSON.stringify({ type: 'article', url }))
+    }));
+
+    await ddb.send(new UpdateItemCommand({
+      TableName: QUEUE_TABLE,
+      Key: { url: { S: url } },
+      UpdateExpression: 'SET processedAt = :now',
+      ExpressionAttributeValues: { ':now': { S: new Date().toISOString() } }
+    }));
+  }
+
+  return { statusCode: 200, body: `Triggered ${tasks.length} articles` };
+};


### PR DESCRIPTION
## Summary
- add DynamoDB tables for article queue and translation quality metrics
- wire translation quality table into ingestion lambda
- deploy new ingestion-agent lambda and permissions
- enable automatic validation in verification lambda

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6862fdd86d8483249770be5daec045d9