### PR TITLE
Fix /chat page route

### DIFF
--- a/ui/src/app/app-routing.module.ts
+++ b/ui/src/app/app-routing.module.ts
@@ -10,5 +10,10 @@ export const routes: Routes = [
     loadComponent: () => import('./pages/verification-review/verification-review.component').then(m => m.VerificationReviewComponent),
     canActivate: [AuthGuard]
   },
+  {
+    path: 'chat',
+    loadComponent: () => import('./pages/learn/learn.component').then(m => m.LearnComponent),
+    canActivate: [AuthGuard]
+  },
   { path: '**', redirectTo: '' }
 ];


### PR DESCRIPTION
## Summary
- add Angular route for the chat page to enable direct access

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68634b2a10608324872cefe70ff3e8fb