### PR TITLE
Refactor CORS handling for verification endpoints

### DIFF
--- a/lib/fijian-rag-app-stack.ts
+++ b/lib/fijian-rag-app-stack.ts
@@ -511,27 +511,7 @@ export class FijianRagAppStack extends cdk.Stack {
       apiKeyRequired: true
     });
 
-    verifyResource.addMethod('OPTIONS', new apigateway.MockIntegration({
-      integrationResponses: [{
-        statusCode: '200',
-        responseParameters: {
-          'method.response.header.Access-Control-Allow-Headers': "'Content-Type,X-Amz-Date,Authorization,X-Api-Key'",
-          'method.response.header.Access-Control-Allow-Origin': "'*'",
-          'method.response.header.Access-Control-Allow-Methods': "'GET,POST,OPTIONS'"
-        }
-      }],
-      passthroughBehavior: apigateway.PassthroughBehavior.NEVER,
-      requestTemplates: { 'application/json': '{"statusCode": 200}' }
-    }), {
-      methodResponses: [{
-        statusCode: '200',
-        responseParameters: {
-          'method.response.header.Access-Control-Allow-Headers': true,
-          'method.response.header.Access-Control-Allow-Origin': true,
-          'method.response.header.Access-Control-Allow-Methods': true
-        }
-      }]
-    });
+    addCorsOptions(verifyResource);
 
 
     // === /verify-item endpoint ===
@@ -542,27 +522,7 @@ export class FijianRagAppStack extends cdk.Stack {
       authorizationType: apigateway.AuthorizationType.COGNITO
     });
 
-    submitVerifyResource.addMethod('OPTIONS', new apigateway.MockIntegration({
-      integrationResponses: [{
-        statusCode: '200',
-        responseParameters: {
-          'method.response.header.Access-Control-Allow-Headers': "'Content-Type,X-Amz-Date,Authorization,X-Api-Key'",
-          'method.response.header.Access-Control-Allow-Origin': "'*'",
-          'method.response.header.Access-Control-Allow-Methods': "'GET,POST,OPTIONS'"
-        }
-      }],
-      passthroughBehavior: apigateway.PassthroughBehavior.NEVER,
-      requestTemplates: { 'application/json': '{"statusCode": 200}' }
-    }), {
-      methodResponses: [{
-        statusCode: '200',
-        responseParameters: {
-          'method.response.header.Access-Control-Allow-Headers': true,
-          'method.response.header.Access-Control-Allow-Origin': true,
-          'method.response.header.Access-Control-Allow-Methods': true
-        }
-      }]
-    });
+    addCorsOptions(submitVerifyResource);
 
     // === Chat and Learning endpoints ===
     const learnResource = unifiedApi.root.addResource('learn');


### PR DESCRIPTION
## Summary
- clean up CORS setup for the verification endpoints
- use `addCorsOptions` helper for `/verify-items` and `/verify-item`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6864695aff3c832494a6149d333dce1c