### PR TITLE
Use env API key for Angular

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,17 @@ We welcome grants, public funding, and partnerships with:
 4. Run the test to invoke the lambda. It reads all `.json` files in that folder (except `chapter.json`), merges them, and writes `chapter.json` back to the same path.
 5. The `chapter.json` file automatically triggers the **LoadLearningModuleJsonLambda** to ingest the module into DynamoDB and OpenSearch.
 
+## API Key Configuration
+
+The Angular frontend reads its API key from the `API_KEY` environment variable when the application is built. Provide this value whenever you run the Angular CLI:
+
+```bash
+# Development server
+API_KEY=your-key ng serve
+
+# Production build
+API_KEY=your-key ng build
+```
+
+Set `API_KEY` in your deployment pipeline so the compiled application includes the correct key.
+

--- a/ui/src/environments/environment.prod.ts
+++ b/ui/src/environments/environment.prod.ts
@@ -1,6 +1,6 @@
 export const environment = {
-    production: true,
-    apiUrl: 'https://qbfl8hrn0g.execute-api.us-west-2.amazonaws.com/prod',
-    apiKey: 'GtI1FXSndrwoaZWRKfSg2NtuBI4qqJU1gqPVw1H9'
-  };
+  production: true,
+  apiUrl: 'https://qbfl8hrn0g.execute-api.us-west-2.amazonaws.com/prod',
+  apiKey: process.env['API_KEY'] ?? ''
+};
   

--- a/ui/src/environments/environment.ts
+++ b/ui/src/environments/environment.ts
@@ -1,6 +1,6 @@
 export const environment = {
-    production: false,
-    apiUrl: 'https://qbfl8hrn0g.execute-api.us-west-2.amazonaws.com/prod',
-    apiKey: 'GtI1FXSndrwoaZWRKfSg2NtuBI4qqJU1gqPVw1H9'
-  };
+  production: false,
+  apiUrl: 'https://qbfl8hrn0g.execute-api.us-west-2.amazonaws.com/prod',
+  apiKey: process.env['API_KEY'] ?? ''
+};
   


### PR DESCRIPTION
## Summary
- read API key from the `API_KEY` environment variable in Angular environments
- document API key usage in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68646961daa88324948b48fc313cbbbd