### PR TITLE
Remove legacy API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,17 +81,4 @@ We welcome grants, public funding, and partnerships with:
 4. Run the test to invoke the lambda. It reads all `.json` files in that folder (except `chapter.json`), merges them, and writes `chapter.json` back to the same path.
 5. The `chapter.json` file automatically triggers the **LoadLearningModuleJsonLambda** to ingest the module into DynamoDB and OpenSearch.
 
-## API Key Configuration
-
-The Angular frontend reads its API key from the `API_KEY` environment variable when the application is built. Provide this value whenever you run the Angular CLI:
-
-```bash
-# Development server
-API_KEY=your-key ng serve
-
-# Production build
-API_KEY=your-key ng build
-```
-
-Set `API_KEY` in your deployment pipeline so the compiled application includes the correct key.
 

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -24,7 +24,6 @@
         "angular-auth-oidc-client": "19.0.1",
         "aws-amplify": "^5.3.11",
         "bootstrap": "^5.3.3",
-        "cd": "^0.3.3",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "ui": "^0.2.4",
@@ -12931,14 +12930,6 @@
         "no-case": "^3.0.4",
         "tslib": "^2.0.3",
         "upper-case-first": "^2.0.2"
-      }
-    },
-    "node_modules/cd": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/cd/-/cd-0.3.3.tgz",
-      "integrity": "sha512-X2y0Ssu48ucdkrNgCdg6k3EZWjWVy/dsEywUUTeZEIW31f3bQfq65Svm+TzU1Hz+qqhdmyCdjGhUvRsSKHl/mw==",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/chalk": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -26,7 +26,6 @@
     "angular-auth-oidc-client": "19.0.1",
     "aws-amplify": "^5.3.11",
     "bootstrap": "^5.3.3",
-    "cd": "^0.3.3",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "ui": "^0.2.4",

--- a/ui/src/app/services/verification.service.ts
+++ b/ui/src/app/services/verification.service.ts
@@ -1,6 +1,5 @@
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { environment } from '../../environments/environment';
 import { OidcSecurityService } from 'angular-auth-oidc-client';
 import { from, Observable } from 'rxjs';
 
@@ -18,8 +17,7 @@ export class VerificationService {
   private async getHeaders(): Promise<HttpHeaders> {
     const token = (await this.oidcSecurityService.getIdToken().toPromise()) || '';
     return new HttpHeaders({
-      Authorization: `Bearer ${token}`,
-      'x-api-key': environment.apiKey
+      Authorization: `Bearer ${token}`
     });
   }
 
@@ -34,14 +32,15 @@ export class VerificationService {
 
 
   getStats() {
-    const headers = new HttpHeaders({ 'x-api-key': environment.apiKey });
-    return this.http.get<{
-      stats: {
-        vocab: { total: number; verified: number };
-        phrase: { total: number; verified: number };
-        paragraph: { total: number; verified: number };
-      };
-    }>(`${this.baseUrl}-items?type=vocab`, { headers });
+    return from(this.getHeaders().then(headers =>
+      this.http.get<{
+        stats: {
+          vocab: { total: number; verified: number };
+          phrase: { total: number; verified: number };
+          paragraph: { total: number; verified: number };
+        };
+      }>(`${this.baseUrl}-items?type=vocab`, { headers }).toPromise()
+    ));
   }
 
 

--- a/ui/src/environments/environment.prod.ts
+++ b/ui/src/environments/environment.prod.ts
@@ -1,6 +1,6 @@
 export const environment = {
   production: true,
   apiUrl: 'https://qbfl8hrn0g.execute-api.us-west-2.amazonaws.com/prod',
-  apiKey: process.env['API_KEY'] ?? ''
+  // API key removed; Cognito authentication is used for all endpoints.
 };
   

--- a/ui/src/environments/environment.ts
+++ b/ui/src/environments/environment.ts
@@ -1,6 +1,7 @@
 export const environment = {
   production: false,
   apiUrl: 'https://qbfl8hrn0g.execute-api.us-west-2.amazonaws.com/prod',
-  apiKey: process.env['API_KEY'] ?? ''
+  // API key was previously required for API Gateway calls. The backend now
+  // uses Cognito authentication exclusively, so no API key is needed.
 };
   


### PR DESCRIPTION
## Summary
- drop outdated API key configuration from Angular and README
- remove API key generation and requirement from CDK stack
- secure previously public endpoints with Cognito
- delete unused `cd` dependency

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6865aff2d0688324a7c70bacb46ff21b